### PR TITLE
CI: add code coverage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -592,3 +592,20 @@ volumes:
 node:
   instance: sgx
 
+---
+
+kind: pipeline
+name: coverage
+
+steps:
+- name: coverage
+  image: baiduxlab/useful-docker:ubuntu.1604.nightly
+  commands:
+  - apt-get update && apt-get install -qq libclang-common-3.9-dev llvm-3.9-dev git llvm curl
+  - . /root/.profile
+  - ./ci/build-lcov
+  - ./ci/run-cov
+  - bash -c "bash <(curl -s https://codecov.io/bash) -f final.info"
+  environment:
+    CODECOV_TOKEN:
+      from_secret: CODECOV_TOKEN

--- a/ci/build-lcov
+++ b/ci/build-lcov
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+if [ ! -e lcov/ ] ; then
+  git clone https://github.com/linux-test-project/lcov.git
+  cd lcov && make install
+fi

--- a/ci/gbdt-cov-rustc
+++ b/ci/gbdt-cov-rustc
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+get_crate_name()
+{
+  while [[ $# -gt 1 ]] ; do
+    v=$1
+    case $v in
+      --crate-name)
+        echo $2
+        return
+        ;;
+    esac
+    shift
+  done
+}
+
+case $(get_crate_name "$@") in
+    gbdt | convert_xgboost | test-agaricus-lepiota | test-batch | test-iris | test-multithreads | test-xgb-binary-logistic | test-xgb-binary-logitraw | test-xgb-multi-softmax | test-xgb-multi-softprob | test-xgb-rank-pairwise | test-xgb-reg-linear | test-xgb-reg-logistic)
+    EXTRA=$COVERAGE_OPTIONS
+    ;;
+  *)
+    EXTRA=$OPTIONS
+    ;;
+esac
+
+exec "$@" $EXTRA

--- a/ci/llvm-gcov
+++ b/ci/llvm-gcov
@@ -1,0 +1,2 @@
+#!/bin/sh -e
+llvm-cov gcov $*

--- a/ci/run-cov
+++ b/ci/run-cov
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+for path in /usr/lib/llvm-3.9/lib/clang/3.9.[0-9]/lib/linux/; do LLVM_PATH=$path; done
+export OPTIONS="-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Zno-landing-pads -L$LLVM_PATH -lclang_rt.profile-x86_64"
+export COVERAGE_OPTIONS="-Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Cpasses=insert-gcov-profiling -Zno-landing-pads -L$LLVM_PATH -lclang_rt.profile-x86_64"
+export CARGO_INCREMENTAL=0
+
+LCOVOPT="--gcov-tool ./ci/llvm-gcov --rc lcov_branch_coverage=1 --rc lcov_excl_line=assert"
+LCOV="/usr/local/bin/lcov"
+
+# cleanup all
+rm -rf *.info *.gcda *.gcno
+cargo clean
+
+# unit tests of gbdt
+export RUSTC_WRAPPER="./ci/gbdt-cov-rustc"
+cargo rustc --package gbdt --all-features --profile test --lib
+rm ./target/debug/gbdt-*.d
+./target/debug/gbdt-*
+${LCOV} ${LCOVOPT} --capture --directory . --base-directory . -o unittest.info
+
+# cleanup target
+rm -rf *.gcda *.gcno
+cargo clean
+
+# integration tests
+export RUSTC_WRAPPER="./ci/gbdt-cov-rustc"
+cargo rustc --all-features --examples
+find target/debug/examples -executable -type f -exec ./{} \;
+${LCOV} ${LCOVOPT} --capture --directory . --base-directory . -o examples.info
+
+# combining and filtering
+${LCOV} ${LCOVOPT} --add unittest.info --add examples.info -o coverage.info
+${LCOV} ${LCOVOPT} --extract coverage.info `find "$(cd src; pwd)" -name "*.rs"` -o final.info
+
+# generate report if not in CI
+if [[ "$CI" != true ]]; then
+  genhtml --branch-coverage --demangle-cpp --legend final.info -o target/coverage/ --ignore-errors source
+fi


### PR DESCRIPTION
This PR add auto code coverage into CI.
  - https://ci.mesalock-linux.org/mesalock-linux/gbdt-rs/31/25/2

Since all stdout will be written into database. If possible, please remove some logs of examples into stdout to reduce the execution time of the pipeline.