### PR TITLE
Enhance error return to fulfill std::error::Error + 'static + Send + Sync

### DIFF
--- a/src/decision_tree.rs
+++ b/src/decision_tree.rs
@@ -1746,7 +1746,9 @@ impl DecisionTree {
     /// let node: Value = serde_json::from_str(data).unwrap();
     /// let dt = DecisionTree::get_from_xgboost(&node);
     /// ```
-    pub fn get_from_xgboost(node: &serde_json::Value) -> Result<Self, Box<dyn Error>> {
+    pub fn get_from_xgboost(
+        node: &serde_json::Value,
+    ) -> Result<Self, Box<dyn Error + Sync + Send>> {
         // Parameters are not used in prediction process, so we use default parameters.
         let mut tree = DecisionTree::new();
         let index = tree.tree.add_root(BinaryTreeNode::new(DTNode::new()));
@@ -1759,7 +1761,7 @@ impl DecisionTree {
         &mut self,
         index: TreeIndex,
         node: &serde_json::Value,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), Box<dyn Error + Sync + Send>> {
         {
             let node_ref = self
                 .tree
@@ -1798,7 +1800,8 @@ impl DecisionTree {
                 } else if missing == right_child {
                     node_ref.value.missing = 1;
                 } else {
-                    let err: Box<dyn Error> = From::from("not support extra missing node".to_string());
+                    let err: Box<dyn Error> =
+                        From::from("not support extra missing node".to_string());
                     return Err(err);
                 }
             }

--- a/src/decision_tree.rs
+++ b/src/decision_tree.rs
@@ -1748,7 +1748,7 @@ impl DecisionTree {
     /// ```
     pub fn get_from_xgboost(
         node: &serde_json::Value,
-    ) -> Result<Self, Box<dyn Error + Sync + Send>> {
+    ) -> Result<Self, Box<dyn Error + 'static + Sync + Send>> {
         // Parameters are not used in prediction process, so we use default parameters.
         let mut tree = DecisionTree::new();
         let index = tree.tree.add_root(BinaryTreeNode::new(DTNode::new()));
@@ -1761,7 +1761,7 @@ impl DecisionTree {
         &mut self,
         index: TreeIndex,
         node: &serde_json::Value,
-    ) -> Result<(), Box<dyn Error + Sync + Send>> {
+    ) -> Result<(), Box<dyn Error + 'static + Sync + Send>> {
         {
             let node_ref = self
                 .tree

--- a/src/decision_tree.rs
+++ b/src/decision_tree.rs
@@ -99,9 +99,9 @@ use crate::binary_tree::BinaryTree;
 use crate::binary_tree::BinaryTreeNode;
 use crate::binary_tree::TreeIndex;
 use crate::config::Loss;
+use crate::errors::{GbdtError, Result};
 #[cfg(feature = "enable_training")]
 use crate::fitness::almost_equal;
-use std::error::Error;
 
 #[cfg(feature = "enable_training")]
 use rand::prelude::SliceRandom;
@@ -1746,9 +1746,7 @@ impl DecisionTree {
     /// let node: Value = serde_json::from_str(data).unwrap();
     /// let dt = DecisionTree::get_from_xgboost(&node);
     /// ```
-    pub fn get_from_xgboost(
-        node: &serde_json::Value,
-    ) -> Result<Self, Box<dyn Error + 'static + Sync + Send>> {
+    pub fn get_from_xgboost(node: &serde_json::Value) -> Result<Self> {
         // Parameters are not used in prediction process, so we use default parameters.
         let mut tree = DecisionTree::new();
         let index = tree.tree.add_root(BinaryTreeNode::new(DTNode::new()));
@@ -1757,11 +1755,7 @@ impl DecisionTree {
     }
 
     /// Recursively build the tree node from the JSON value.
-    fn add_node_from_json(
-        &mut self,
-        index: TreeIndex,
-        node: &serde_json::Value,
-    ) -> Result<(), Box<dyn Error + 'static + Sync + Send>> {
+    fn add_node_from_json(&mut self, index: TreeIndex, node: &serde_json::Value) -> Result<()> {
         {
             let node_ref = self
                 .tree
@@ -1769,7 +1763,7 @@ impl DecisionTree {
                 .expect("node should not be empty!");
             // This is the leaf node
             if let serde_json::Value::Number(pred) = &node["leaf"] {
-                let leaf_value = pred.as_f64().ok_or("parse 'leaf' error")?;
+                let leaf_value = pred.as_f64().ok_or_else(|| "parse 'leaf' error")?;
                 node_ref.value.pred = leaf_value as ValueType;
                 node_ref.value.is_leaf = true;
                 return Ok(());
@@ -1777,14 +1771,16 @@ impl DecisionTree {
                 // feature value
                 let feature_value = node["split_condition"]
                     .as_f64()
-                    .ok_or("parse 'split condition' error")?;
+                    .ok_or_else(|| "parse 'split condition' error")?;
                 node_ref.value.feature_value = feature_value as ValueType;
 
                 // feature index
                 let feature_index = match node["split"].as_i64() {
                     Some(v) => v,
                     None => {
-                        let feature_name = node["split"].as_str().ok_or("parse 'split' error")?;
+                        let feature_name = node["split"]
+                            .as_str()
+                            .ok_or_else(|| "parse 'split' error")?;
                         let feature_str: String = feature_name.chars().skip(3).collect();
                         feature_str.parse::<i64>()?
                     }
@@ -1792,31 +1788,33 @@ impl DecisionTree {
                 node_ref.value.feature_index = feature_index as usize;
 
                 // handle unknown feature
-                let missing = node["missing"].as_i64().ok_or("parse 'missing' error")?;
-                let left_child = node["yes"].as_i64().ok_or("parse 'yes' error")?;
-                let right_child = node["no"].as_i64().ok_or("parse 'no' error")?;
+                let missing = node["missing"]
+                    .as_i64()
+                    .ok_or_else(|| "parse 'missing' error")?;
+                let left_child = node["yes"].as_i64().ok_or_else(|| "parse 'yes' error")?;
+                let right_child = node["no"].as_i64().ok_or_else(|| "parse 'no' error")?;
                 if missing == left_child {
                     node_ref.value.missing = -1;
                 } else if missing == right_child {
                     node_ref.value.missing = 1;
                 } else {
-                    let err: Box<dyn Error + Sync + Send> =
-                        From::from("not support extra missing node".to_string());
-                    return Err(err);
+                    return Err(GbdtError::NotSupportExtraMissingNode);
                 }
             }
         }
 
         // ids for children
-        let left_child = node["yes"].as_i64().ok_or("parse 'yes' error")?;
-        let right_child = node["no"].as_i64().ok_or("parse 'no' error")?;
+        let left_child = node["yes"].as_i64().ok_or_else(|| "parse 'yes' error")?;
+        let right_child = node["no"].as_i64().ok_or_else(|| "parse 'no' error")?;
         let children = node["children"]
             .as_array()
-            .ok_or("parse 'children' error")?;
+            .ok_or_else(|| "parse 'children' error")?;
         let mut find_left = false;
         let mut find_right = false;
         for child in children.iter() {
-            let node_id = child["nodeid"].as_i64().ok_or("parse 'nodeid' error")?;
+            let node_id = child["nodeid"]
+                .as_i64()
+                .ok_or_else(|| "parse 'nodeid' error")?;
 
             // build left child
             if node_id == left_child {
@@ -1838,8 +1836,7 @@ impl DecisionTree {
         }
 
         if (!find_left) || (!find_right) {
-            let err: Box<dyn Error + Sync + Send> = From::from("children not found".to_string());
-            return Err(err);
+            return Err(GbdtError::ChildrenNotFound);
         }
         Ok(())
     }

--- a/src/decision_tree.rs
+++ b/src/decision_tree.rs
@@ -1800,7 +1800,7 @@ impl DecisionTree {
                 } else if missing == right_child {
                     node_ref.value.missing = 1;
                 } else {
-                    let err: Box<dyn Error> =
+                    let err: Box<dyn Error + Sync + Send> =
                         From::from("not support extra missing node".to_string());
                     return Err(err);
                 }
@@ -1838,7 +1838,7 @@ impl DecisionTree {
         }
 
         if (!find_left) || (!find_right) {
-            let err: Box<dyn Error> = From::from("children not found".to_string());
+            let err: Box<dyn Error + Sync + Send> = From::from("children not found".to_string());
             return Err(err);
         }
         Ok(())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,72 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::io;
+use std::num;
+
+pub type Result<T> = std::result::Result<T, GbdtError>;
+
+#[derive(Debug)]
+pub enum GbdtError {
+    NotSupportExtraMissingNode,
+    ChildrenNotFound,
+    IO(io::Error),
+    ParseInt(num::ParseIntError),
+    ParseFloat(num::ParseFloatError),
+    SerdeJson(serde_json::Error),
+}
+
+impl From<&str> for GbdtError {
+    fn from(err: &str) -> GbdtError {
+        GbdtError::IO(io::Error::new(io::ErrorKind::Other, err))
+    }
+}
+
+impl From<serde_json::Error> for GbdtError {
+    fn from(err: serde_json::Error) -> GbdtError {
+        GbdtError::SerdeJson(err)
+    }
+}
+
+impl From<num::ParseFloatError> for GbdtError {
+    fn from(err: num::ParseFloatError) -> GbdtError {
+        GbdtError::ParseFloat(err)
+    }
+}
+
+impl From<num::ParseIntError> for GbdtError {
+    fn from(err: num::ParseIntError) -> GbdtError {
+        GbdtError::ParseInt(err)
+    }
+}
+
+impl From<io::Error> for GbdtError {
+    fn from(err: io::Error) -> GbdtError {
+        GbdtError::IO(err)
+    }
+}
+
+impl Display for GbdtError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match *self {
+            GbdtError::NotSupportExtraMissingNode => write!(f, "Not support extra missing node"),
+            GbdtError::ChildrenNotFound => write!(f, "Children not found"),
+            GbdtError::IO(ref e) => write!(f, "IO error: {}", e),
+            GbdtError::ParseInt(ref e) => write!(f, "ParseInt error: {}", e),
+            GbdtError::ParseFloat(ref e) => write!(f, "ParseFloat error: {}", e),
+            GbdtError::SerdeJson(ref e) => write!(f, "SerdeJson error: {}", e),
+        }
+    }
+}
+
+impl Error for GbdtError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            GbdtError::NotSupportExtraMissingNode => None,
+            GbdtError::ChildrenNotFound => None,
+            GbdtError::IO(ref e) => Some(e),
+            GbdtError::ParseInt(ref e) => Some(e),
+            GbdtError::ParseFloat(ref e) => Some(e),
+            GbdtError::SerdeJson(ref e) => Some(e),
+        }
+    }
+}

--- a/src/gradient_boost.rs
+++ b/src/gradient_boost.rs
@@ -707,7 +707,7 @@ impl GBDT {
     /// // Save model.
     /// // gbdt.save_model("gbdt.model");
     /// ```
-    pub fn save_model(&self, filename: &str) -> Result<(), Box<dyn Error + Sync + Send>> {
+    pub fn save_model(&self, filename: &str) -> Result<(), Box<dyn Error + 'static + Sync + Send>> {
         let mut file = File::create(filename)?;
         let serialized = serde_json::to_string(self)?;
         file.write_all(serialized.as_bytes())?;
@@ -726,7 +726,7 @@ impl GBDT {
     ///
     /// # Error
     /// Error when get exception during model file parsing or deserialize.
-    pub fn load_model(filename: &str) -> Result<Self, Box<dyn Error + Sync + Send>> {
+    pub fn load_model(filename: &str) -> Result<Self, Box<dyn Error + 'static + Sync + Send>> {
         let mut file = File::open(filename)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
@@ -749,7 +749,7 @@ impl GBDT {
     pub fn from_xgoost_dump(
         model_file: &str,
         objective: &str,
-    ) -> Result<Self, Box<dyn Error + Sync + Send>> {
+    ) -> Result<Self, Box<dyn Error + 'static + Sync + Send>> {
         let tree_file = File::open(&model_file)?;
         let reader = BufReader::new(tree_file);
         let mut all_lines: Vec<String> = Vec::new();

--- a/src/gradient_boost.rs
+++ b/src/gradient_boost.rs
@@ -707,7 +707,7 @@ impl GBDT {
     /// // Save model.
     /// // gbdt.save_model("gbdt.model");
     /// ```
-    pub fn save_model(&self, filename: &str) -> Result<(), Box<dyn Error>> {
+    pub fn save_model(&self, filename: &str) -> Result<(), Box<dyn Error + Sync + Send>> {
         let mut file = File::create(filename)?;
         let serialized = serde_json::to_string(self)?;
         file.write_all(serialized.as_bytes())?;
@@ -726,7 +726,7 @@ impl GBDT {
     ///
     /// # Error
     /// Error when get exception during model file parsing or deserialize.
-    pub fn load_model(filename: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn load_model(filename: &str) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let mut file = File::open(filename)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
@@ -746,7 +746,10 @@ impl GBDT {
     ///
     /// # Error
     /// Error when get exception during model file parsing.
-    pub fn from_xgoost_dump(model_file: &str, objective: &str) -> Result<Self, Box<dyn Error>> {
+    pub fn from_xgoost_dump(
+        model_file: &str,
+        objective: &str,
+    ) -> Result<Self, Box<dyn Error + Sync + Send>> {
         let tree_file = File::open(&model_file)?;
         let reader = BufReader::new(tree_file);
         let mut all_lines: Vec<String> = Vec::new();

--- a/src/input.rs
+++ b/src/input.rs
@@ -289,7 +289,7 @@ pub fn infer(file_name: &str) -> InputFormat {
 pub fn load_csv(
     file: &mut File,
     input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
+) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -343,7 +343,7 @@ pub fn load_csv(
 pub fn load_txt(
     file: &mut File,
     input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
+) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -423,7 +423,7 @@ pub fn load_txt(
 pub fn load(
     file_name: &str,
     input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
+) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
     let mut file = File::open(file_name.to_string())?;
     match input_format.ftype {
         FileFormat::CSV => load_csv(&mut file, input_format),

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,6 +28,7 @@
 use std::prelude::v1::*;
 
 use crate::decision_tree::{Data, DataVec, ValueType, VALUE_TYPE_UNKNOWN};
+use crate::errors::Result;
 
 cfg_if! {
     if #[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))] {
@@ -37,7 +38,6 @@ cfg_if! {
         use std::io::{BufRead, BufReader, Seek, SeekFrom};
     } else {
         use std::collections::HashMap;
-        use std::error::Error;
         #[cfg(not(feature = "mesalock_sgx"))]
         use std::fs::File;
         #[cfg(feature = "mesalock_sgx")]
@@ -286,10 +286,7 @@ pub fn infer(file_name: &str) -> InputFormat {
 ///
 /// # Error
 /// Raise error if file cannot be read correctly.
-pub fn load_csv(
-    file: &mut File,
-    input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
+pub fn load_csv(file: &mut File, input_format: InputFormat) -> Result<DataVec> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -340,10 +337,7 @@ pub fn load_csv(
 ///
 /// # Error
 /// Raise error if file cannot be read correctly.
-pub fn load_txt(
-    file: &mut File,
-    input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
+pub fn load_txt(file: &mut File, input_format: InputFormat) -> Result<DataVec> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -420,10 +414,7 @@ pub fn load_txt(
 ///
 /// # Error
 /// Raise error if file cannot be open correctly.
-pub fn load(
-    file_name: &str,
-    input_format: InputFormat,
-) -> Result<DataVec, Box<dyn Error + 'static + Sync + Send>> {
+pub fn load(file_name: &str, input_format: InputFormat) -> Result<DataVec> {
     let mut file = File::open(file_name.to_string())?;
     match input_format.ftype {
         FileFormat::CSV => load_csv(&mut file, input_format),

--- a/src/input.rs
+++ b/src/input.rs
@@ -286,7 +286,10 @@ pub fn infer(file_name: &str) -> InputFormat {
 ///
 /// # Error
 /// Raise error if file cannot be read correctly.
-pub fn load_csv(file: &mut File, input_format: InputFormat) -> Result<DataVec, Box<dyn Error>> {
+pub fn load_csv(
+    file: &mut File,
+    input_format: InputFormat,
+) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -337,7 +340,10 @@ pub fn load_csv(file: &mut File, input_format: InputFormat) -> Result<DataVec, B
 ///
 /// # Error
 /// Raise error if file cannot be read correctly.
-pub fn load_txt(file: &mut File, input_format: InputFormat) -> Result<DataVec, Box<dyn Error>> {
+pub fn load_txt(
+    file: &mut File,
+    input_format: InputFormat,
+) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
     file.seek(SeekFrom::Start(0))?;
     let mut dv = Vec::new();
 
@@ -414,7 +420,10 @@ pub fn load_txt(file: &mut File, input_format: InputFormat) -> Result<DataVec, B
 ///
 /// # Error
 /// Raise error if file cannot be open correctly.
-pub fn load(file_name: &str, input_format: InputFormat) -> Result<DataVec, Box<dyn Error>> {
+pub fn load(
+    file_name: &str,
+    input_format: InputFormat,
+) -> Result<DataVec, Box<dyn Error + Sync + Send>> {
     let mut file = File::open(file_name.to_string())?;
     match input_format.ftype {
         FileFormat::CSV => load_csv(&mut file, input_format),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ extern crate sgx_tstd as std;
 pub mod binary_tree;
 pub mod config;
 pub mod decision_tree;
+pub mod errors;
 pub mod fitness;
 pub mod gradient_boost;
 


### PR DESCRIPTION
Hi, I am a user of this wonderful lib, a huge big thanks first! 

recently, I try to use [anyhow](https://docs.rs/anyhow/1.0.38/anyhow/) in my application and causing this error

```rust
E0277: `dyn std::error::Error` cannot be shared between threads safely  `dyn std::error::Error` cannot be shared bet
ween threads safely  help: the trait `std::marker::Sync` is not implemented for `dyn std::error::Error` note: requir
ed because of the requirements on the impl of `std::marker::Sync` for `std::ptr::Unique<dyn std::error::Error>` note
: required because it appears within the type `std::boxed::Box<dyn std::error::Error>` note: required because of the
 requirements on the impl of `std::convert::From<std::boxed::Box<dyn std::error::Error>>` for `anyhow::Error` note:
required by `std::convert::From::from`
```

so I modify all the return error type from
```rust
Box<dyn std::error::Error>
```
into
```rust
Box<dyn std::error::Error + 'static + Sync + Send>
```

this may lead to some benefits:
1. able to use this lib in multithreads
2. able to use anyhow this modern application library

hope you will accept this,
thank you.