### PR TITLE
fix: correct typo and fix feature index extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Cargo.lock
 
 # ignore files
 .vscode/*
+.idea/*
 .DS_Store
 
 # Automatically generated during cargo test

--- a/examples/test-batch.rs
+++ b/examples/test-batch.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_reg_linear/xgb.model "reg:linear" xgb-data/xgb_reg_linear/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_reg_linear/gbdt.model", "reg:linear")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_reg_linear/gbdt.model", "reg:linear")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-multithreads.rs
+++ b/examples/test-multithreads.rs
@@ -15,7 +15,7 @@ fn main() {
     let test_file = "xgb-data/xgb_reg_linear/machine.txt.test";
 
     // load model
-    let gbdt = GBDT::from_xgoost_dump(model_path, "reg:linear").expect("faild to load model");
+    let gbdt = GBDT::from_xgboost_dump(model_path, "reg:linear").expect("faild to load model");
 
     // load test data
     let mut fmt = input::InputFormat::txt_format();

--- a/examples/test-xgb-binary-logistic.rs
+++ b/examples/test-xgb-binary-logistic.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_binary_logistic/xgb.model "binary:logistic" xgb-data/xgb_binary_logistic/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_binary_logistic/gbdt.model", "binary:logistic")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_binary_logistic/gbdt.model", "binary:logistic")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-binary-logitraw.rs
+++ b/examples/test-xgb-binary-logitraw.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_binary_logitraw/xgb.model "binary:logitraw" xgb-data/xgb_binary_logitraw/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_binary_logitraw/gbdt.model", "binary:logitraw")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_binary_logitraw/gbdt.model", "binary:logitraw")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-multi-softmax.rs
+++ b/examples/test-xgb-multi-softmax.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_multi_softmax/xgb.model "multi:softmax" xgb-data/xgb_multi_softmax/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_multi_softmax/gbdt.model", "multi:softmax")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_multi_softmax/gbdt.model", "multi:softmax")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-multi-softprob.rs
+++ b/examples/test-xgb-multi-softprob.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_multi_softprob/xgb.model "multi:softprob" xgb-data/xgb_multi_softprob/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_multi_softprob/gbdt.model", "multi:softprob")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_multi_softprob/gbdt.model", "multi:softprob")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-rank-pairwise.rs
+++ b/examples/test-xgb-rank-pairwise.rs
@@ -10,7 +10,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_rank_pairwise/xgb.model "rank:pairwise" xgb-data/xgb_rank_pairwise/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_rank_pairwise/gbdt.model", "rank:pairwise")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_rank_pairwise/gbdt.model", "rank:pairwise")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-reg-linear.rs
+++ b/examples/test-xgb-reg-linear.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_reg_linear/xgb.model "reg:linear" xgb-data/xgb_reg_linear/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_reg_linear/gbdt.model", "reg:linear")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_reg_linear/gbdt.model", "reg:linear")
         .expect("failed to load model");
 
     // load test data

--- a/examples/test-xgb-reg-logistic.rs
+++ b/examples/test-xgb-reg-logistic.rs
@@ -11,7 +11,7 @@ fn main() {
     // Call this command to convert xgboost model:
     // python examples/convert_xgboost.py xgb-data/xgb_reg_logistic/xgb.model "reg:logistic" xgb-data/xgb_reg_logistic/gbdt.model
     // load model
-    let gbdt = GBDT::from_xgoost_dump("xgb-data/xgb_reg_logistic/gbdt.model", "reg:logistic")
+    let gbdt = GBDT::from_xgboost_dump("xgb-data/xgb_reg_logistic/gbdt.model", "reg:logistic")
         .expect("failed to load model");
 
     // load test data

--- a/src/decision_tree.rs
+++ b/src/decision_tree.rs
@@ -1781,8 +1781,10 @@ impl DecisionTree {
                         let feature_name = node["split"]
                             .as_str()
                             .ok_or("parse 'split' error")?;
-                        let feature_str: String = feature_name.chars().skip(3).collect();
-                        feature_str.parse::<i64>()?
+                        let digits = feature_name
+                        .rsplit_once(|c: char| !c.is_ascii_digit())
+                        .map_or(feature_name, |(_head, digits)| digits);
+                        digits.parse::<i64>()?
                     }
                 };
                 node_ref.value.feature_index = feature_index as usize;

--- a/src/gradient_boost.rs
+++ b/src/gradient_boost.rs
@@ -491,7 +491,7 @@ impl GBDT {
     /// use gbdt::input::{load, InputFormat};
     /// use gbdt::decision_tree::DataVec;
     /// let gbdt =
-    ///     GBDT::from_xgoost_dump("xgb-data/xgb_multi_softmax/gbdt.model", "multi:softmax").unwrap();
+    ///     GBDT::from_xgboost_dump("xgb-data/xgb_multi_softmax/gbdt.model", "multi:softmax").unwrap();
     /// let test_file = "xgb-data/xgb_multi_softmax/dermatology.data.test";
     /// let mut fmt = InputFormat::csv_format();
     /// fmt.set_label_index(34);
@@ -741,15 +741,15 @@ impl GBDT {
     /// ```rust
     /// use gbdt::gradient_boost::GBDT;
     /// let gbdt =
-    ///     GBDT::from_xgoost_dump("xgb-data/xgb_binary_logistic/gbdt.model", "binary:logistic").unwrap();
+    ///     GBDT::from_xgboost_dump("xgb-data/xgb_binary_logistic/gbdt.model", "binary:logistic").unwrap();
     /// ```
     ///
     /// # Error
     /// Error when get exception during model file parsing.
-    pub fn from_xgoost_dump(model_file: &str, objective: &str) -> Result<Self> {
+    pub fn from_xgboost_dump(model_file: &str, objective: &str) -> Result<Self> {
         let tree_file = File::open(model_file)?;
         let reader = BufReader::new(tree_file);
-        Self::from_xgoost_reader(reader, objective)
+        Self::from_xgboost_reader(reader, objective)
     }
 
     /// Load the model from xgboost's model using a reader. The xgboost's model should be converted by "convert_xgboost.py"
@@ -759,12 +759,12 @@ impl GBDT {
     /// ```rust
     /// use gbdt::gradient_boost::GBDT;
     /// let gbdt =
-    ///     GBDT::from_xgoost_reader(std::io::Cursor::new(include_str!("../xgb-data/xgb_binary_logistic/gbdt.model")), "binary:logistic").unwrap();
+    ///     GBDT::from_xgboost_reader(std::io::Cursor::new(include_str!("../xgb-data/xgb_binary_logistic/gbdt.model")), "binary:logistic").unwrap();
     /// ```
     ///
     /// # Error
     /// Error when get exception during model parsing.
-    pub fn from_xgoost_reader<R>(reader: R, objective: &str) -> Result<Self>
+    pub fn from_xgboost_reader<R>(reader: R, objective: &str) -> Result<Self>
     where
         R: std::io::BufRead,
     {


### PR DESCRIPTION
The snippet of code:
```rust 
  let feature_str: String = feature_name.chars().skip(3).collect();
  feature_str.parse::<i64>()?
```
fails when the name of the feature has less than 3 characters, for example `"f1"` it becomes `""` a more robust approach would be to extract the digits and the end of the string.

Additionally corrected a typo.